### PR TITLE
Modified response models for specific mess routes

### DIFF
--- a/src/app/models/responses/_mess.py
+++ b/src/app/models/responses/_mess.py
@@ -88,7 +88,7 @@ class DeleteMessResponseModel_ERR_404(BaseModel):
 
 
 class GetCurrentMessMenuDetailsResponseModel(BaseModel):
-    menu: MessMenuResponseModel
+    menu: MessMenuResponseModel | None
 
 
 class GetCurrentMessMenuDetailsResponseModel_ERR_404(BaseModel):
@@ -96,7 +96,7 @@ class GetCurrentMessMenuDetailsResponseModel_ERR_404(BaseModel):
 
 
 class GetCurrentMessMenuDetailsByDayResponseModel(BaseModel):
-    menu: DayMenuResponseModel
+    menu: DayMenuResponseModel | None
 
 
 class GetCurrentMessMenuDetailsByDayResponseModel_ERR_404(BaseModel):
@@ -108,7 +108,7 @@ class GetMessMenuDetailsResponseModel(BaseModel):
 
 
 class GetMessMenuDetailsByIDsResponseModel(BaseModel):
-    menu: MessMenuResponseModel
+    menu: MessMenuResponseModel | None
 
 
 class GetMessMenuDetailsByIDsResponseModel_ERR_404(BaseModel):


### PR DESCRIPTION
Added possibility of the menu of a mess being returned as `null`. The response had been defined as not null, which was the cause of the error.